### PR TITLE
Fix #16: Engine sprockets initializer valid for Rails3 and Rails4

### DIFF
--- a/lib/smt_rails/engine.rb
+++ b/lib/smt_rails/engine.rb
@@ -5,7 +5,7 @@ module SmtRails
     end
 
     initializer "sprockets.smt_rails", :group => :all do |app|
-      config.assets.configure do |env|
+      app.config.assets.configure do |env|
         env.register_engine(".#{SmtRails.template_extension}", Tilt)
       end
       app.config.assets.paths << SmtRails.template_base_path


### PR DESCRIPTION
Fix #16: `method_missing': undefined method `assets' in Rails 3.2.22

Tested with:
- [x] Rails 3.2.22.2
- [x] Rails 4.2.6